### PR TITLE
Use const when defining element counter

### DIFF
--- a/exporter/exporter.bpf.c
+++ b/exporter/exporter.bpf.c
@@ -8,7 +8,7 @@
 
 #include "nat64_exporter_stats.h"
 
-__s64 bpf_map_sum_elem_count(struct bpf_map *map) __ksym;
+__s64 bpf_map_sum_elem_count(const struct bpf_map *map) __ksym;
 
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);


### PR DESCRIPTION
One line change to make compilation working on some systems.